### PR TITLE
bugfix - pass 'key' from ItemAdd to ItemAddReal

### DIFF
--- a/Gtk.NodeGraph/Node.cs
+++ b/Gtk.NodeGraph/Node.cs
@@ -1007,7 +1007,7 @@ namespace Gtk.NodeGraph
         /// </returns>
         public NodeSocket ItemAdd(Widget widget, NodeSocketIO mode, uint key = 0)
         {
-            return ItemAddReal(widget, mode);
+            return ItemAddReal(widget, mode, key);
         }
 
         #endregion


### PR DESCRIPTION
Found 'key' was not being assigned even when passed in with the `ItemAdd` constructor.  issue was `ItemAdd` did not pass this property along to `ItemAddReal`.

example (before):
```    
public ResultNode()
{
      Label = "Result";

      _value = new Label("0") { Xalign = -1.0f };
      _nodeSocket = ItemAdd(_value, NodeSocketIO.Sink, 2);   
}
```
Note that key (defined as '2' in constructor in example above) remains default '0'. 

This was due to `ItemAdd` not passing key along:
```
        public NodeSocket ItemAdd(Widget widget, NodeSocketIO mode, uint key = 0)
        {
            return ItemAddReal(widget, mode);
        }

```

Fixed:

```
        public NodeSocket ItemAdd(Widget widget, NodeSocketIO mode, uint key = 0)
        {
            return ItemAddReal(widget, mode, key);
        }
```